### PR TITLE
Add video player labels param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,29 @@
-## 0.0.6
- - upgraded to Dart 2.17.0
- - bug fixes
- - Added some examples
-## 0.0.5
+## 0.0.8
+* Added `PodPlayerLabels` param to `PodVideoPlayer` widget
+* Added PodPlayerLabels usage example in `from_asset` file
 
-* features
+## 0.0.6
+* Upgraded to Dart 2.17.0
+* Bug fixes
+* Added some examples
+
+## 0.0.5
+* Features
   - Added support for thumbnails
   - Added `isFullScreen` getter to controller
-* updated docs
-## 0.0.4
+* Updated docs
 
-* features
+## 0.0.4
+* Features
   - support for RTL (by @karbalaidev)
   - initialVideoQuality added
-* bug fixes
+* Bug fixes
 
 ## 0.0.3
+* Bug fix #4
 
-*  bug fix #4
 ## 0.0.2
+* Ignored .mp4 video file in pub
 
-* ignored .mp4 video file in pub
 ## 0.0.1
-
-* initial release
+* Initial release

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This plugin built upon flutter's official [`video_player`](https://pub.dartlang.
 - Change `playback speed`
 - Custom overlay
 - Custom progress bar
+- Custom labels
 - `Change video quality` (for vimeo and youtube)
 - Enable/disable fullscreen player
 - [TODO] support for live youtube video
@@ -222,6 +223,7 @@ class PlayVideoFromNetwork extends StatefulWidget {
 
 class _PlayVideoFromNetworkState extends State<PlayVideoFromNetwork> {
   late final PodPlayerController controller;
+
   @override
   void initState() {
     controller = PodPlayerController(
@@ -231,6 +233,7 @@ class _PlayVideoFromNetworkState extends State<PlayVideoFromNetwork> {
     )..initialise();
     super.initState();
   }
+
   @override
   void dispose() {
     controller.dispose();
@@ -250,14 +253,14 @@ class _PlayVideoFromNetworkState extends State<PlayVideoFromNetwork> {
 ## Configure pod player
 
 ```dart
-controller = PodPlayerController(
-      playVideoFrom: PlayVideoFrom.youtube('https://youtu.be/A3ltMaM6noM'),
-      podPlayerConfig: const PodPlayerConfig(
-          autoPlay: true,
-          isLooping: false,
-          initialVideoQuality: 360
-        )
-    )..initialise();
+  controller = PodPlayerController(
+    playVideoFrom: PlayVideoFrom.youtube('https://youtu.be/A3ltMaM6noM'),
+    podPlayerConfig: const PodPlayerConfig(
+      autoPlay: true,
+      isLooping: false,
+      initialVideoQuality: 360
+    )
+  )..initialise();
 ```
 
 ## Add Thumbnail
@@ -272,6 +275,24 @@ PodVideoPlayer(
     fit: BoxFit.cover,
   ),
 ),
+```
+
+## Add PodPlayerLabels (custom labels)
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return Scaffold(
+    body: PodVideoPlayer(
+      controller: controller,
+      podPlayerLabels: const PodPlayerLabels(
+        play: "Play label customized",
+        pause: "Pause label customized",
+        ...
+      ),
+    ),
+  );
+}
 ```
 
 ## How to play video from youtube
@@ -291,6 +312,7 @@ class PlayVideoFromYoutube extends StatefulWidget {
 
 class _PlayVideoFromYoutubeState extends State<PlayVideoFromYoutube> {
   late final PodPlayerController controller;
+
   @override
   void initState() {
     controller = PodPlayerController(
@@ -298,6 +320,7 @@ class _PlayVideoFromYoutubeState extends State<PlayVideoFromYoutube> {
     )..initialise();
     super.initState();
   }
+
   @override
   void dispose() {
     controller.dispose();
@@ -331,6 +354,7 @@ class PlayVideoFromVimeo extends StatefulWidget {
 
 class _PlayVideoFromVimeoState extends State<PlayVideoFromVimeo> {
   late final PodPlayerController controller;
+
   @override
   void initState() {
     controller = PodPlayerController(
@@ -338,6 +362,7 @@ class _PlayVideoFromVimeoState extends State<PlayVideoFromVimeo> {
     )..initialise();
     super.initState();
   }
+
   @override
   void dispose() {
     controller.dispose();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,7 +64,7 @@ class _MainPageState extends State<MainPage> {
                   Navigator.of(context).pushNamed('/fromNetworkQualityUrls'),
             ),
             _button(
-              'Play video from Asset',
+              'Play video from Asset (with custom labels)',
               onPressed: () => Navigator.of(context).pushNamed('/fromAsset'),
             ),
             _button(

--- a/example/lib/screens/from_asset.dart
+++ b/example/lib/screens/from_asset.dart
@@ -27,8 +27,29 @@ class _PlayVideoFromAssetState extends State<PlayVideoFromAsset> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Play video from Assets')),
-      body: Center(child: PodVideoPlayer(controller: controller)),
+      appBar: AppBar(
+        title: const Text('Play video from Asset (with custom labels)'),
+      ),
+      body: Center(
+        child: PodVideoPlayer(
+          controller: controller,
+          podPlayerLabels: const PodPlayerLabels(
+            play: "PLAY",
+            pause: "PAUSE",
+            error: "ERROR WHILE TRYING TO PLAY VIDEO",
+            exitFullScreen: "EXIT FULL SCREEN",
+            fullscreen: "FULL SCREEN",
+            loopVideo: "LOOP VIDEO",
+            mute: "MUTE",
+            playbackSpeed: "PLAYBACK SPEED",
+            settings: "SETTINGS",
+            unmute: "UNMUTE",
+            optionEnabled: "YES",
+            optionDisabled: "NO",
+            quality: "QUALITY",
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/pod_player.dart
+++ b/lib/pod_player.dart
@@ -6,6 +6,7 @@ export 'src/controllers/pod_player_controller.dart';
 export 'src/models/overlay_options.dart';
 export 'src/models/play_video_from.dart';
 export 'src/models/pod_player_config.dart';
+export 'src/models/pod_player_labels.dart';
 export 'src/models/pod_progress_bar_config.dart';
 export 'src/models/vimeo_models.dart';
 export 'src/pod_player.dart';

--- a/lib/src/controllers/pod_base_controller.dart
+++ b/lib/src/controllers/pod_base_controller.dart
@@ -5,6 +5,9 @@ class _PodBaseController extends GetxController {
   ///main video controller
   VideoPlayerController? _videoCtr;
 
+  ///video player labels
+  late PodPlayerLabels podPlayerLabels;
+
   ///
   late PodVideoPlayerType _videoPlayerType;
 

--- a/lib/src/models/pod_player_labels.dart
+++ b/lib/src/models/pod_player_labels.dart
@@ -1,0 +1,32 @@
+class PodPlayerLabels {
+  final String play;
+  final String pause;
+  final String mute;
+  final String unmute;
+  final String settings;
+  final String fullscreen;
+  final String exitFullScreen;
+  final String loopVideo;
+  final String playbackSpeed;
+  final String quality;
+  final String optionEnabled;
+  final String optionDisabled;
+  final String error;
+
+  /// Labels displayed in the video player progress bar and when an error occurs
+  const PodPlayerLabels({
+    this.play = 'Play',
+    this.pause = 'Pause',
+    this.mute = 'Mute',
+    this.unmute = 'Unmute',
+    this.settings = 'Settings',
+    this.fullscreen = 'Fullscreen',
+    this.exitFullScreen = 'Exit full screen',
+    this.loopVideo = 'Loop Video',
+    this.playbackSpeed = 'Playback speed',
+    this.error = 'Error while playing video',
+    this.quality = 'Quality',
+    this.optionEnabled = 'on',
+    this.optionDisabled = 'off',
+  });
+}

--- a/lib/src/pod_player.dart
+++ b/lib/src/pod_player.dart
@@ -29,6 +29,7 @@ class PodVideoPlayer extends StatefulWidget {
   final bool matchVideoAspectRatioToFrame;
   final bool matchFrameAspectRatioToVideo;
   final PodProgressBarConfig podProgressBarConfig;
+  final PodPlayerLabels podPlayerLabels;
   final Widget Function(OverLayOptions options)? overlayBuilder;
   final Widget Function()? onVideoError;
   final Widget? videoTitle;
@@ -41,6 +42,7 @@ class PodVideoPlayer extends StatefulWidget {
     this.videoAspectRatio = 16 / 9,
     this.alwaysShowProgressBar = true,
     this.podProgressBarConfig = const PodProgressBarConfig(),
+    this.podPlayerLabels = const PodPlayerLabels(),
     this.overlayBuilder,
     this.videoTitle,
     this.matchVideoAspectRatioToFrame = false,
@@ -59,6 +61,7 @@ class PodVideoPlayer extends StatefulWidget {
     Get.find<PodGetXVideoController>(tag: controller.getTag)
 
       ///add to ui
+      ..podPlayerLabels = podPlayerLabels
       ..alwaysShowProgressBar = alwaysShowProgressBar
       ..podProgressBarConfig = podProgressBarConfig
       ..overlayBuilder = overlayBuilder
@@ -134,16 +137,16 @@ class _PodVideoPlayerState extends State<PodVideoPlayer>
       child: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          children: const [
-            Icon(
+          children: [
+            const Icon(
               Icons.warning,
               color: Colors.yellow,
               size: 32,
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             Text(
-              'Error while playing video',
-              style: TextStyle(color: Colors.red),
+              widget.podPlayerLabels.error,
+              style: const TextStyle(color: Colors.red),
             ),
           ],
         ),

--- a/lib/src/widgets/animated_play_pause_icon.dart
+++ b/lib/src/widgets/animated_play_pause_icon.dart
@@ -61,8 +61,8 @@ class _AnimatedPlayPauseIconState extends State<_AnimatedPlayPauseIcon>
           id: 'podVideoState',
           builder: (_f) => MaterialIconButton(
             toolTipMesg: _f.isvideoPlaying
-                ? 'Pause${kIsWeb ? ' (space)' : ''}'
-                : 'Play${kIsWeb ? ' (space)' : ''}',
+                ? '${_podCtr.podPlayerLabels.pause}${kIsWeb ? ' (space)' : ''}'
+                : '${_podCtr.podPlayerLabels.play}${kIsWeb ? ' (space)' : ''}',
             onPressed:
                 _podCtr.isOverlayVisible ? _podCtr.togglePlayPauseVideo : null,
             child: onStateChange(_podCtr),

--- a/lib/src/widgets/core/overlays/mobile_bottomsheet.dart
+++ b/lib/src/widgets/core/overlays/mobile_bottomsheet.dart
@@ -17,7 +17,7 @@ class _MobileBottomSheet extends StatelessWidget {
         children: [
           if (_podCtr.vimeoOrVideoUrls.isNotEmpty)
             _bottomSheetTiles(
-              title: 'Quality',
+              title: _podCtr.podPlayerLabels.quality,
               icon: Icons.video_settings_rounded,
               subText: '${_podCtr.vimeoPlayingVideoQuality}p',
               onTap: () {
@@ -37,16 +37,18 @@ class _MobileBottomSheet extends StatelessWidget {
               },
             ),
           _bottomSheetTiles(
-            title: 'Loop video',
+            title: _podCtr.podPlayerLabels.loopVideo,
             icon: Icons.loop_rounded,
-            subText: _podCtr.isLooping ? 'On' : 'Off',
+            subText: _podCtr.isLooping
+                ? _podCtr.podPlayerLabels.optionEnabled
+                : _podCtr.podPlayerLabels.optionDisabled,
             onTap: () {
               Navigator.of(context).pop();
               _podCtr.toggleLooping();
             },
           ),
           _bottomSheetTiles(
-            title: 'Playback speed',
+            title: _podCtr.podPlayerLabels.playbackSpeed,
             icon: Icons.slow_motion_video_rounded,
             subText: _podCtr.currentPaybackSpeed,
             onTap: () {
@@ -222,8 +224,8 @@ class _MobileOverlayBottomControlles extends StatelessWidget {
               const Spacer(),
               MaterialIconButton(
                 toolTipMesg: _podCtr.isFullScreen
-                    ? 'Exit full screen${kIsWeb ? ' (f)' : ''}'
-                    : 'Fullscreen${kIsWeb ? ' (f)' : ''}',
+                    ? '${_podCtr.podPlayerLabels.exitFullScreen}${kIsWeb ? ' (f)' : ''}'
+                    : '${_podCtr.podPlayerLabels.fullscreen}${kIsWeb ? ' (f)' : ''}',
                 color: itemColor,
                 onPressed: () {
                   if (_podCtr.isOverlayVisible) {

--- a/lib/src/widgets/core/overlays/mobile_overlay.dart
+++ b/lib/src/widgets/core/overlays/mobile_overlay.dart
@@ -73,7 +73,7 @@ class _MobileOverlay extends StatelessWidget {
                 ),
               ),
               MaterialIconButton(
-                toolTipMesg: 'More',
+                toolTipMesg: _podCtr.podPlayerLabels.settings,
                 color: itemColor,
                 onPressed: () {
                   if (_podCtr.isOverlayVisible) {

--- a/lib/src/widgets/core/overlays/web_dropdown_menu.dart
+++ b/lib/src/widgets/core/overlays/web_dropdown_menu.dart
@@ -24,7 +24,7 @@ class _WebSettingsDropdownState extends State<_WebSettingsDropdown> {
         tag: widget.tag,
         builder: (_podCtr) {
           return MaterialIconButton(
-            toolTipMesg: 'Settings',
+            toolTipMesg: _podCtr.podPlayerLabels.settings,
             color: Colors.white,
             child: const Icon(Icons.settings),
             onPressed: () => _podCtr.isFullScreen
@@ -38,7 +38,7 @@ class _WebSettingsDropdownState extends State<_WebSettingsDropdown> {
                     PopupMenuItem(
                       value: 'OUALITY',
                       child: _bottomSheetTiles(
-                        title: 'Quality',
+                        title: _podCtr.podPlayerLabels.quality,
                         icon: Icons.video_settings_rounded,
                         subText: '${_podCtr.vimeoPlayingVideoQuality}p',
                       ),
@@ -46,15 +46,17 @@ class _WebSettingsDropdownState extends State<_WebSettingsDropdown> {
                   PopupMenuItem(
                     value: 'LOOP',
                     child: _bottomSheetTiles(
-                      title: 'Loop video',
+                      title: _podCtr.podPlayerLabels.loopVideo,
                       icon: Icons.loop_rounded,
-                      subText: _podCtr.isLooping ? 'On' : 'Off',
+                      subText: _podCtr.isLooping
+                          ? _podCtr.podPlayerLabels.optionEnabled
+                          : _podCtr.podPlayerLabels.optionDisabled,
                     ),
                   ),
                   PopupMenuItem(
                     value: 'SPEED',
                     child: _bottomSheetTiles(
-                      title: 'Playback speed',
+                      title: _podCtr.podPlayerLabels.playbackSpeed,
                       icon: Icons.slow_motion_video_rounded,
                       subText: _podCtr.currentPaybackSpeed,
                     ),

--- a/lib/src/widgets/core/overlays/web_overlay.dart
+++ b/lib/src/widgets/core/overlays/web_overlay.dart
@@ -99,8 +99,8 @@ class _WebOverlayBottomControlles extends StatelessWidget {
                           id: 'volume',
                           builder: (_podCtr) => MaterialIconButton(
                             toolTipMesg: _podCtr.isMute
-                                ? 'Unmute${kIsWeb ? ' (m)' : ''}'
-                                : 'Mute${kIsWeb ? ' (m)' : ''}',
+                                ? '${_podCtr.podPlayerLabels.unmute}${kIsWeb ? ' (m)' : ''}'
+                                : '${_podCtr.podPlayerLabels.mute}${kIsWeb ? ' (m)' : ''}',
                             color: itemColor,
                             onPressed: _podCtr.toggleMute,
                             child: Icon(
@@ -150,8 +150,8 @@ class _WebOverlayBottomControlles extends StatelessWidget {
                         _WebSettingsDropdown(tag: tag),
                         MaterialIconButton(
                           toolTipMesg: _podCtr.isFullScreen
-                              ? 'Exit full screen${kIsWeb ? ' (f)' : ''}'
-                              : 'Fullscreen${kIsWeb ? ' (f)' : ''}',
+                              ? '${_podCtr.podPlayerLabels.exitFullScreen}${kIsWeb ? ' (f)' : ''}'
+                              : '${_podCtr.podPlayerLabels.fullscreen}${kIsWeb ? ' (f)' : ''}',
                           color: itemColor,
                           onPressed: () =>
                               _onFullScreenToggle(_podCtr, context),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pod_player
 description: Vimeo and youtube player for flutter, Pod player provides customizable video player controls that support android, ios and web.
-version: 0.0.6
+version: 0.0.8
 homepage: https://github.com/newtaDev/pod_player
 
 environment:


### PR DESCRIPTION
## Description
A parameter called `PodPlayerLabels` has been added to `PodVideoPlayer`. This parameter is a way for users to insert custom labels into the video player. The labels mentioned are for:

  - Play icon
  - Pause icon
  - Mute icon
  - Unmute icon
  - Settings icon
  - Full screen icon
  - ExitFullScreen icon
  - Loop video option
  - Playback speed option
  - Quality option
  - Option status indicator (on/off)
  - Error message

## Supported platforms
- Android,
- iOS,
- Web.

## Additional information
I did a branch from `master`. But, I noticed the last version (so far) of this plugin (0.0.7) is in another branch, `fix/videos_list`. By this, the current code doesn't have the modifications of `fix/videos_list` branch. I hope that's not a big problem to the merge.