### PR TITLE
View improvements and customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ class _PlayVideoFromNetworkState extends State<PlayVideoFromNetwork> {
     podPlayerConfig: const PodPlayerConfig(
       autoPlay: true,
       isLooping: false,
-      initialVideoQuality: 360
+      videoQualityPriority: [720, 360]
     )
   )..initialise();
 ```

--- a/example/lib/examples/load_vimeo_from_urls.dart
+++ b/example/lib/examples/load_vimeo_from_urls.dart
@@ -41,7 +41,7 @@ class VimeoVideoViewerState extends State<VimeoVideoViewer> {
     controller = PodPlayerController(
       playVideoFrom: PlayVideoFrom.networkQualityUrls(videoUrls: urls!),
       podPlayerConfig: const PodPlayerConfig(
-        initialVideoQuality: 360,
+        videoQualityPriority: [360],
       ),
     )..initialise();
   }

--- a/example/lib/examples/load_youtube_from_urls.dart
+++ b/example/lib/examples/load_youtube_from_urls.dart
@@ -44,7 +44,7 @@ class _YoutubeVideoViewerState extends State<YoutubeVideoViewer> {
     controller = PodPlayerController(
       playVideoFrom: PlayVideoFrom.networkQualityUrls(videoUrls: urls!),
       podPlayerConfig: const PodPlayerConfig(
-        initialVideoQuality: 360,
+        videoQualityPriority: [360],
       ),
     )..initialise();
   }

--- a/example/lib/screens/from_youtube.dart
+++ b/example/lib/screens/from_youtube.dart
@@ -1,5 +1,5 @@
-import 'package:pod_player/pod_player.dart';
 import 'package:flutter/material.dart';
+import 'package:pod_player/pod_player.dart';
 
 class PlayVideoFromYoutube extends StatefulWidget {
   const PlayVideoFromYoutube({Key? key}) : super(key: key);
@@ -16,7 +16,7 @@ class _PlayVideoFromVimeoIdState extends State<PlayVideoFromYoutube> {
     controller = PodPlayerController(
       playVideoFrom: PlayVideoFrom.youtube('https://youtu.be/A3ltMaM6noM'),
       podPlayerConfig: const PodPlayerConfig(
-        initialVideoQuality: 360,
+        videoQualityPriority: [720, 360],
         autoPlay: false,
       ),
     )..initialise();

--- a/lib/src/controllers/pod_getx_video_controller.dart
+++ b/lib/src/controllers/pod_getx_video_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:universal_html/html.dart' as _html;
@@ -206,11 +207,7 @@ class PodGetXVideoController extends _PodGesturesController {
         if (isFullScreen) {
           _html.document.exitFullscreen();
           if (!isWebPopupOverlayOpen) {
-            disableFullScreen(
-              appContext,
-              tag,
-              onExitFullscreen: podPlayerConfig.onExitFullscreen,
-            );
+            disableFullScreen(appContext, tag);
           }
         }
       }
@@ -223,18 +220,11 @@ class PodGetXVideoController extends _PodGesturesController {
     if (isFullScreen) {
       _html.document.exitFullscreen();
       if (!isWebPopupOverlayOpen) {
-        disableFullScreen(
-          context,
-          tag,
-          onExitFullscreen: podPlayerConfig.onExitFullscreen,
-        );
+        disableFullScreen(context, tag);
       }
     } else {
       _html.document.documentElement?.requestFullscreen();
-      enableFullScreen(
-        tag,
-        onEnterFullscreen: podPlayerConfig.onEnterFullscreen,
-      );
+      enableFullScreen(tag);
     }
   }
 

--- a/lib/src/controllers/pod_getx_video_controller.dart
+++ b/lib/src/controllers/pod_getx_video_controller.dart
@@ -95,7 +95,7 @@ class PodGetXVideoController extends _PodUiController {
         break;
       case PodVideoPlayerType.networkQualityUrls:
         final _url = await getUrlFromVideoQualityUrls(
-          quality: podPlayerConfig.initialVideoQuality,
+          qualityList: podPlayerConfig.videoQualityPriority,
           videoUrls: playVideoFrom.videoQualityUrls!,
         );
 
@@ -113,8 +113,9 @@ class PodGetXVideoController extends _PodUiController {
       case PodVideoPlayerType.youtube:
         final _urls =
             await getVideoQualityUrlsFromYoutube(playVideoFrom.dataSource!);
+
         final _url = await getUrlFromVideoQualityUrls(
-          quality: podPlayerConfig.initialVideoQuality ?? 360,
+          qualityList: podPlayerConfig.videoQualityPriority,
           videoUrls: _urls,
         );
 
@@ -130,11 +131,10 @@ class PodGetXVideoController extends _PodUiController {
 
         break;
       case PodVideoPlayerType.vimeo:
-
-        ///
-        final _url = await getVideoUrlFromVimeoId(
-          quality: podPlayerConfig.initialVideoQuality,
-          videoId: playVideoFrom.dataSource,
+        await getQualityUrlsFromVimeoId(playVideoFrom.dataSource!);
+        final _url = await getUrlFromVideoQualityUrls(
+          qualityList: podPlayerConfig.videoQualityPriority,
+          videoUrls: vimeoOrVideoUrls,
         );
 
         _videoCtr = VideoPlayerController.network(
@@ -205,7 +205,13 @@ class PodGetXVideoController extends _PodUiController {
       if (event.isKeyPressed(LogicalKeyboardKey.escape)) {
         if (isFullScreen) {
           _html.document.exitFullscreen();
-          if (!isWebPopupOverlayOpen) disableFullScreen(appContext, tag);
+          if (!isWebPopupOverlayOpen) {
+            disableFullScreen(
+              appContext,
+              tag,
+              onExitFullscreen: podPlayerConfig.onExitFullscreen,
+            );
+          }
         }
       }
 
@@ -216,10 +222,19 @@ class PodGetXVideoController extends _PodUiController {
   void toggleFullScreenOnWeb(BuildContext context, String tag) {
     if (isFullScreen) {
       _html.document.exitFullscreen();
-      if (!isWebPopupOverlayOpen) disableFullScreen(context, tag);
+      if (!isWebPopupOverlayOpen) {
+        disableFullScreen(
+          context,
+          tag,
+          onExitFullscreen: podPlayerConfig.onExitFullscreen,
+        );
+      }
     } else {
       _html.document.documentElement?.requestFullscreen();
-      enableFullScreen(tag);
+      enableFullScreen(
+        tag,
+        onEnterFullscreen: podPlayerConfig.onEnterFullscreen,
+      );
     }
   }
 

--- a/lib/src/controllers/pod_player_controller.dart
+++ b/lib/src/controllers/pod_player_controller.dart
@@ -218,16 +218,32 @@ class PodPlayerController {
     return _ctr.onLeftDoubleTap(seconds: seconds);
   }
 
-  /// Enables video player to fullscreen mode
+  /// Enables video player to fullscreen mode.
+  ///
+  /// If [PodPlayerConfig.onEnterFullscreen] is set, you must handle the device
+  /// orientation by yourself.
   void enableFullScreen() {
     _html.document.documentElement?.requestFullscreen();
-    _ctr.enableFullScreen(getTag);
+    _ctr.enableFullScreen(
+      getTag,
+      onEnterFullscreen: podPlayerConfig.onEnterFullscreen,
+    );
   }
 
-  /// Disables fullscreen mode
+  /// Disables fullscreen mode.
+  ///
+  /// If [PodPlayerConfig.onExitFullscreen] is set, you must handle the device
+  /// orientation by yourself.
   void disableFullScreen(BuildContext context) {
     _html.document.exitFullscreen();
-    if (!_ctr.isWebPopupOverlayOpen) _ctr.disableFullScreen(context, getTag);
+
+    if (!_ctr.isWebPopupOverlayOpen) {
+      _ctr.disableFullScreen(
+        context,
+        getTag,
+        onExitFullscreen: podPlayerConfig.onExitFullscreen,
+      );
+    }
   }
 
   /// listener for the changes in the quality of the video

--- a/lib/src/controllers/pod_player_controller.dart
+++ b/lib/src/controllers/pod_player_controller.dart
@@ -220,29 +220,22 @@ class PodPlayerController {
 
   /// Enables video player to fullscreen mode.
   ///
-  /// If [PodPlayerConfig.onEnterFullscreen] is set, you must handle the device
+  /// If onToggleFullScreen is set, you must handle the device
   /// orientation by yourself.
   void enableFullScreen() {
     _html.document.documentElement?.requestFullscreen();
-    _ctr.enableFullScreen(
-      getTag,
-      onEnterFullscreen: podPlayerConfig.onEnterFullscreen,
-    );
+    _ctr.enableFullScreen(getTag);
   }
 
   /// Disables fullscreen mode.
   ///
-  /// If [PodPlayerConfig.onExitFullscreen] is set, you must handle the device
+  /// If onToggleFullScreen is set, you must handle the device
   /// orientation by yourself.
   void disableFullScreen(BuildContext context) {
     _html.document.exitFullscreen();
 
     if (!_ctr.isWebPopupOverlayOpen) {
-      _ctr.disableFullScreen(
-        context,
-        getTag,
-        onExitFullscreen: podPlayerConfig.onExitFullscreen,
-      );
+      _ctr.disableFullScreen(context, getTag);
     }
   }
 

--- a/lib/src/controllers/pod_ui_controller.dart
+++ b/lib/src/controllers/pod_ui_controller.dart
@@ -8,7 +8,10 @@ class _PodUiController extends _PodBaseController {
   DecorationImage? videoThumbnail;
 
   /// Callback when fullscreen mode changes
-  void Function(bool isFullScreen)? onFullScreenToggle;
+  Future Function(bool isFullScreen)? onToggleFullScreen;
+
+  /// Builder for custom loading widget
+  WidgetBuilder? onLoading;
 
   ///video player labels
   PodPlayerLabels podPlayerLabels = const PodPlayerLabels();

--- a/lib/src/controllers/pod_video_controller.dart
+++ b/lib/src/controllers/pod_video_controller.dart
@@ -159,14 +159,11 @@ class _PodVideoController extends _PodUiController {
     update(['update-all']);
   }
 
-  Future<void> enableFullScreen(
-    String tag, {
-    AsyncCallback? onEnterFullscreen,
-  }) async {
+  Future<void> enableFullScreen(String tag) async {
     podLog('-full-screen-enable-entred');
     if (!isFullScreen) {
-      if (onEnterFullscreen != null) {
-        await onEnterFullscreen();
+      if (onToggleFullScreen != null) {
+        await onToggleFullScreen!(true);
       } else {
         await Future.wait([
           SystemChrome.setPreferredOrientations(
@@ -181,7 +178,6 @@ class _PodVideoController extends _PodUiController {
 
       _enableFullScreenView(tag);
       isFullScreen = true;
-      onFullScreenToggle?.call(isFullScreen);
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         update(['full-screen']);
         update(['update-all']);
@@ -192,13 +188,12 @@ class _PodVideoController extends _PodUiController {
   Future<void> disableFullScreen(
     BuildContext context,
     String tag, {
-    AsyncCallback? onExitFullscreen,
     bool enablePop = true,
   }) async {
     podLog('-full-screen-disable-entred');
     if (isFullScreen) {
-      if (onExitFullscreen != null) {
-        await onExitFullscreen();
+      if (onToggleFullScreen != null) {
+        await onToggleFullScreen!(false);
       } else {
         await Future.wait([
           SystemChrome.setPreferredOrientations([
@@ -215,7 +210,6 @@ class _PodVideoController extends _PodUiController {
 
       if (enablePop) _exitFullScreenView(context, tag);
       isFullScreen = false;
-      onFullScreenToggle?.call(isFullScreen);
       update(['full-screen']);
       update(['update-all']);
     }
@@ -248,7 +242,7 @@ class _PodVideoController extends _PodUiController {
     }
   }
 
-  ///claculates video `position` or `duration`
+  /// Calculates video `position` or `duration`
   String calculateVideoDuration(Duration _duration) {
     final _totalHour = _duration.inHours == 0 ? '' : '${_duration.inHours}:';
     final _totalMinute = _duration.toString().split(':')[1];

--- a/lib/src/controllers/pod_video_quality_controller.dart
+++ b/lib/src/controllers/pod_video_quality_controller.dart
@@ -14,13 +14,10 @@ class _PodVideoQualityController extends _PodVideoController {
   ///*vimeo player configs
   ///
   ///get all  `quality urls`
-  Future<void> getQualityUrlsFromVimeoId({
-    String? videoId,
-  }) async {
+  Future<void> getQualityUrlsFromVimeoId(String videoId) async {
     try {
       podVideoStateChanger(PodVideoState.loading);
-      final _vimeoVideoUrls =
-          await VideoApis.getVimeoVideoQualityUrls(videoId!);
+      final _vimeoVideoUrls = await VideoApis.getVimeoVideoQualityUrls(videoId);
 
       ///
       vimeoOrVideoUrls = _vimeoVideoUrls ?? [];
@@ -57,35 +54,31 @@ class _PodVideoQualityController extends _PodVideoController {
     );
   }
 
-  ///config vimeo player
-  Future<String> getVideoUrlFromVimeoId({
-    String? videoId,
-    int? quality,
-  }) async {
-    await getQualityUrlsFromVimeoId(videoId: videoId);
-    sortQualityVideoUrls(vimeoOrVideoUrls);
-    if (vimeoOrVideoUrls.isEmpty) {
-      throw Exception('videoQuality cannot be empty');
-    }
-    final q = quality ?? vimeoOrVideoUrls[0].quality;
-    final _qualityAndUrl = getQualityUrl(q);
-    _videoQualityUrl = _qualityAndUrl.url;
-    vimeoPlayingVideoQuality = _qualityAndUrl.quality;
-    return _videoQualityUrl;
-  }
-
   Future<String> getUrlFromVideoQualityUrls({
-    int? quality,
+    required List<int> qualityList,
     required List<VideoQalityUrls> videoUrls,
   }) async {
     sortQualityVideoUrls(videoUrls);
     if (vimeoOrVideoUrls.isEmpty) {
       throw Exception('videoQuality cannot be empty');
     }
-    final q = quality ?? vimeoOrVideoUrls[0].quality;
-    final _qualityAndUrl = getQualityUrl(q);
-    _videoQualityUrl = _qualityAndUrl.url;
-    vimeoPlayingVideoQuality = _qualityAndUrl.quality;
+
+    final fallback = vimeoOrVideoUrls[0];
+    VideoQalityUrls? urlWithQuality;
+    for (final quality in qualityList) {
+      urlWithQuality = vimeoOrVideoUrls.firstWhere(
+        (url) => url.quality == quality,
+        orElse: () => fallback,
+      );
+
+      if (urlWithQuality != fallback) {
+        break;
+      }
+    }
+
+    urlWithQuality ??= fallback;
+    _videoQualityUrl = urlWithQuality.url;
+    vimeoPlayingVideoQuality = urlWithQuality.quality;
     return _videoQualityUrl;
   }
 

--- a/lib/src/models/pod_player_config.dart
+++ b/lib/src/models/pod_player_config.dart
@@ -1,15 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
 class PodPlayerConfig {
   final bool autoPlay;
   final bool isLooping;
   final bool forcedVideoFocus;
   final bool wakelockEnabled;
-  final int? initialVideoQuality;
+
+  /// Initial video quality priority. The first available option will be used,
+  /// from start to the end of this list. If all options informed are not
+  /// available or if nothing is provided, 360p is used.
+  ///
+  /// Default value is [1080, 720, 360]
+  final List<int> videoQualityPriority;
+
+  /// Optional callback, fired on full screen mode activation.
+  ///
+  /// Important: If this method is set, the configuration of [DeviceOrientation]
+  /// and [SystemUiMode] is up to you.
+  final AsyncCallback? onEnterFullscreen;
+
+  /// Optional callback, fired on full screen mode deactivation.
+  ///
+  /// Important: If this method is set, the configuration of [DeviceOrientation]
+  /// and [SystemUiMode] is up to you.
+  final AsyncCallback? onExitFullscreen;
+
+  /// Sets a custom loading widget.
+  /// If no widget is informed, a default [CircularProgressIndicator] will be shown.
+  final Widget Function()? onLoading;
+
   const PodPlayerConfig({
     this.autoPlay = true,
     this.isLooping = false,
     this.forcedVideoFocus = false,
     this.wakelockEnabled = true,
-    this.initialVideoQuality,
+    this.videoQualityPriority =  const [1080, 720, 360],
+    this.onEnterFullscreen,
+    this.onExitFullscreen,
+    this.onLoading,
   });
 
   PodPlayerConfig copyWith({
@@ -17,14 +47,20 @@ class PodPlayerConfig {
     bool? isLooping,
     bool? forcedVideoFocus,
     bool? wakelockEnabled,
-    int? initialVideoQuality,
+    List<int>? videoQualityPriority,
+    AsyncCallback? onEnterFullscreen,
+    AsyncCallback? onExitFullscreen,
+    Widget Function()? onLoading,
   }) {
     return PodPlayerConfig(
       autoPlay: autoPlay ?? this.autoPlay,
       isLooping: isLooping ?? this.isLooping,
       forcedVideoFocus: forcedVideoFocus ?? this.forcedVideoFocus,
       wakelockEnabled: wakelockEnabled ?? this.wakelockEnabled,
-      initialVideoQuality: initialVideoQuality ?? this.initialVideoQuality,
+      videoQualityPriority: videoQualityPriority ?? this.videoQualityPriority,
+      onEnterFullscreen: onEnterFullscreen ?? this.onEnterFullscreen,
+      onExitFullscreen: onExitFullscreen ?? this.onExitFullscreen,
+      onLoading: onLoading ?? this.onLoading,
     );
   }
 }

--- a/lib/src/models/pod_player_config.dart
+++ b/lib/src/models/pod_player_config.dart
@@ -1,7 +1,3 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-
 class PodPlayerConfig {
   final bool autoPlay;
   final bool isLooping;
@@ -15,31 +11,12 @@ class PodPlayerConfig {
   /// Default value is [1080, 720, 360]
   final List<int> videoQualityPriority;
 
-  /// Optional callback, fired on full screen mode activation.
-  ///
-  /// Important: If this method is set, the configuration of [DeviceOrientation]
-  /// and [SystemUiMode] is up to you.
-  final AsyncCallback? onEnterFullscreen;
-
-  /// Optional callback, fired on full screen mode deactivation.
-  ///
-  /// Important: If this method is set, the configuration of [DeviceOrientation]
-  /// and [SystemUiMode] is up to you.
-  final AsyncCallback? onExitFullscreen;
-
-  /// Sets a custom loading widget.
-  /// If no widget is informed, a default [CircularProgressIndicator] will be shown.
-  final Widget Function()? onLoading;
-
   const PodPlayerConfig({
     this.autoPlay = true,
     this.isLooping = false,
     this.forcedVideoFocus = false,
     this.wakelockEnabled = true,
     this.videoQualityPriority =  const [1080, 720, 360],
-    this.onEnterFullscreen,
-    this.onExitFullscreen,
-    this.onLoading,
   });
 
   PodPlayerConfig copyWith({
@@ -48,9 +25,6 @@ class PodPlayerConfig {
     bool? forcedVideoFocus,
     bool? wakelockEnabled,
     List<int>? videoQualityPriority,
-    AsyncCallback? onEnterFullscreen,
-    AsyncCallback? onExitFullscreen,
-    Widget Function()? onLoading,
   }) {
     return PodPlayerConfig(
       autoPlay: autoPlay ?? this.autoPlay,
@@ -58,9 +32,6 @@ class PodPlayerConfig {
       forcedVideoFocus: forcedVideoFocus ?? this.forcedVideoFocus,
       wakelockEnabled: wakelockEnabled ?? this.wakelockEnabled,
       videoQualityPriority: videoQualityPriority ?? this.videoQualityPriority,
-      onEnterFullscreen: onEnterFullscreen ?? this.onEnterFullscreen,
-      onExitFullscreen: onExitFullscreen ?? this.onExitFullscreen,
-      onLoading: onLoading ?? this.onLoading,
     );
   }
 }

--- a/lib/src/pod_player.dart
+++ b/lib/src/pod_player.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:lottie/lottie.dart';
 import 'package:universal_html/html.dart' as _html;
@@ -44,7 +45,16 @@ class PodVideoPlayer extends StatefulWidget {
   final Widget? videoTitle;
   final Color? backgroundColor;
   final DecorationImage? videoThumbnail;
-  final void Function(bool isFullScreen)? onFullScreenToggle;
+
+  /// Optional callback, fired when full screen mode toggles.
+  ///
+  /// Important: If this method is set, the configuration of [DeviceOrientation]
+  /// and [SystemUiMode] is up to you.
+  final Future Function(bool isFullScreen)? onToggleFullScreen;
+
+  /// Sets a custom loading widget.
+  /// If no widget is informed, a default [CircularProgressIndicator] will be shown.
+  final WidgetBuilder? onLoading;
 
   PodVideoPlayer({
     Key? key,
@@ -61,7 +71,8 @@ class PodVideoPlayer extends StatefulWidget {
     this.onVideoError,
     this.backgroundColor,
     this.videoThumbnail,
-    this.onFullScreenToggle,
+    this.onToggleFullScreen,
+    this.onLoading,
   }) : super(key: key) {
     addToUiController();
   }
@@ -72,13 +83,14 @@ class PodVideoPlayer extends StatefulWidget {
   void addToUiController() {
     Get.find<PodGetXVideoController>(tag: controller.getTag)
 
-      ///add to ui controller
+    ///add to ui controller
       ..podPlayerLabels = podPlayerLabels
       ..alwaysShowProgressBar = alwaysShowProgressBar
       ..podProgressBarConfig = podProgressBarConfig
       ..overlayBuilder = overlayBuilder
       ..videoTitle = videoTitle
-      ..onFullScreenToggle = onFullScreenToggle
+      ..onToggleFullScreen = onToggleFullScreen
+      ..onLoading = onLoading
       ..videoThumbnail = videoThumbnail;
   }
 
@@ -201,7 +213,7 @@ class _PodVideoPlayerState extends State<PodVideoPlayer>
   }
 
   Widget _buildLoading() {
-    return widget.controller.podPlayerConfig.onLoading?.call() ??
+    return widget.onLoading?.call(context) ??
         const CircularProgressIndicator(
           backgroundColor: Colors.black87,
           color: Colors.white,

--- a/lib/src/pod_player.dart
+++ b/lib/src/pod_player.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -11,15 +12,23 @@ import 'controllers/pod_getx_video_controller.dart';
 import 'utils/logger.dart';
 import 'widgets/material_icon_button.dart';
 
-part 'widgets/core/pod_core_player.dart';
-part 'widgets/core/overlays/mobile_bottomsheet.dart';
-part 'widgets/core/overlays/mobile_overlay.dart';
-part 'widgets/core/overlays/overlays.dart';
-part 'widgets/core/overlays/web_dropdown_menu.dart';
-part 'widgets/core/overlays/web_overlay.dart';
-part 'widgets/core/video_gesture_detector.dart';
-part 'widgets/full_screen_view.dart';
 part 'widgets/animated_play_pause_icon.dart';
+
+part 'widgets/core/overlays/mobile_bottomsheet.dart';
+
+part 'widgets/core/overlays/mobile_overlay.dart';
+
+part 'widgets/core/overlays/overlays.dart';
+
+part 'widgets/core/overlays/web_dropdown_menu.dart';
+
+part 'widgets/core/overlays/web_overlay.dart';
+
+part 'widgets/core/pod_core_player.dart';
+
+part 'widgets/core/video_gesture_detector.dart';
+
+part 'widgets/full_screen_view.dart';
 
 class PodVideoPlayer extends StatefulWidget {
   final PodPlayerController controller;
@@ -35,6 +44,7 @@ class PodVideoPlayer extends StatefulWidget {
   final Widget? videoTitle;
   final Color? backgroundColor;
   final DecorationImage? videoThumbnail;
+
   PodVideoPlayer({
     Key? key,
     required this.controller,
@@ -60,7 +70,7 @@ class PodVideoPlayer extends StatefulWidget {
   void addToUiController() {
     Get.find<PodGetXVideoController>(tag: controller.getTag)
 
-      ///add to ui controller
+    ///add to ui controller
       ..podPlayerLabels = podPlayerLabels
       ..alwaysShowProgressBar = alwaysShowProgressBar
       ..podProgressBarConfig = podProgressBarConfig
@@ -76,6 +86,7 @@ class PodVideoPlayer extends StatefulWidget {
 class _PodVideoPlayerState extends State<PodVideoPlayer>
     with TickerProviderStateMixin {
   late PodGetXVideoController _podCtr;
+
   // late String tag;
   @override
   void initState() {
@@ -85,7 +96,8 @@ class _PodVideoPlayerState extends State<PodVideoPlayer>
       PodGetXVideoController(),
       permanent: true,
       tag: widget.controller.getTag,
-    )..isVideoUiBinded = true;
+    )
+      ..isVideoUiBinded = true;
     if (_podCtr.wasVideoPlayingOnUiDispose ?? false) {
       _podCtr.podVideoStateChanger(PodVideoState.playing, updateUi: false);
     }
@@ -127,6 +139,7 @@ class _PodVideoPlayerState extends State<PodVideoPlayer>
 
   ///
   double _frameAspectRatio = 16 / 9;
+
   @override
   Widget build(BuildContext context) {
     final circularProgressIndicator = _thumbnailAndLoadingWidget();
@@ -167,20 +180,14 @@ class _PodVideoPlayerState extends State<PodVideoPlayer>
               builder: (_podCtr) {
                 /// Check if has any error
                 if (_podCtr.podVideoState == PodVideoState.error) {
-                  if (widget.onVideoError != null) {
-                    return widget.onVideoError!();
-                  }
-                  return _videoErrorWidget;
+                  return widget.onVideoError?.call() ?? _videoErrorWidget;
                 }
+
                 return AspectRatio(
                   aspectRatio: _frameAspectRatio,
-                  child: Center(
-                    child: _podCtr.videoCtr == null
-                        ? circularProgressIndicator
-                        : _podCtr.videoCtr!.value.isInitialized
-                            ? _buildPlayer()
-                            : circularProgressIndicator,
-                  ),
+                  child: _podCtr.videoCtr?.value.isInitialized ?? false
+                      ? _buildPlayer()
+                      : Center(child: circularProgressIndicator),
                 );
               },
             ),
@@ -190,33 +197,37 @@ class _PodVideoPlayerState extends State<PodVideoPlayer>
     );
   }
 
+  Widget _buildLoading() {
+    return widget.controller.podPlayerConfig.onLoading?.call() ??
+        const CircularProgressIndicator(
+          backgroundColor: Colors.black87,
+          color: Colors.white,
+          strokeWidth: 2,
+        );
+  }
+
   Widget _thumbnailAndLoadingWidget() {
-    return widget.videoThumbnail == null
-        ? const CircularProgressIndicator(
-            backgroundColor: Colors.black87,
-            color: Colors.white,
-            strokeWidth: 2,
-          )
-        : SizedBox.expand(
-            child: TweenAnimationBuilder<double>(
-              builder: (context, value, child) => Opacity(
-                opacity: value,
-                child: child,
-              ),
-              tween: Tween<double>(begin: 0.2, end: 0.7),
-              duration: const Duration(milliseconds: 400),
-              child: DecoratedBox(
-                decoration: BoxDecoration(image: widget.videoThumbnail),
-                child: const Center(
-                  child: CircularProgressIndicator(
-                    backgroundColor: Colors.black87,
-                    color: Colors.white,
-                    strokeWidth: 2,
-                  ),
-                ),
-              ),
+    if (widget.videoThumbnail == null) {
+      return _buildLoading();
+    }
+
+    return SizedBox.expand(
+      child: TweenAnimationBuilder<double>(
+        builder: (context, value, child) =>
+            Opacity(
+              opacity: value,
+              child: child,
             ),
-          );
+        tween: Tween<double>(begin: 0.2, end: 0.7),
+        duration: const Duration(milliseconds: 400),
+        child: DecoratedBox(
+          decoration: BoxDecoration(image: widget.videoThumbnail),
+          child: Center(
+            child: _buildLoading(),
+          ),
+        ),
+      ),
+    );
   }
 
   Widget _buildPlayer() {

--- a/lib/src/widgets/core/overlays/overlays.dart
+++ b/lib/src/widgets/core/overlays/overlays.dart
@@ -2,6 +2,7 @@ part of 'package:pod_player/src/pod_player.dart';
 
 class _VideoOverlays extends StatelessWidget {
   final String tag;
+
   const _VideoOverlays({
     Key? key,
     required this.tag,
@@ -34,23 +35,10 @@ class _VideoOverlays extends StatelessWidget {
             videoPlayerType: _podCtr.videoPlayerType,
             podProgresssBar: _progressBar,
           );
-          return Stack(
-            children: [
-              Positioned.fill(
-                child: _VideoGestureDetector(
-                  tag: tag,
-                  onTap: _podCtr.togglePlayPauseVideo,
-                  onDoubleTap: () =>
-                      _podCtr.toggleFullScreenOnWeb(context, tag),
-                  child: const ColoredBox(
-                    color: Colors.black38,
-                    child: SizedBox.expand(),
-                  ),
-                ),
-              ),
-              _podCtr.overlayBuilder?.call(overlayOptions) ?? const SizedBox(),
-            ],
-          );
+
+          /// Returns the custom overlay, otherwise returns the default
+          /// overlay with gesture detector
+          return _podCtr.overlayBuilder!(overlayOptions);
         },
       );
     } else {

--- a/lib/src/widgets/core/pod_core_player.dart
+++ b/lib/src/widgets/core/pod_core_player.dart
@@ -76,7 +76,7 @@ class _PodCoreVideoPlayer extends StatelessWidget {
                   id: 'podVideoState',
                   builder: (_podCtr) {
                     final loadingWidget =
-                        _podCtr.podPlayerConfig.onLoading?.call() ??
+                        _podCtr.onLoading?.call(context) ??
                             const Center(
                               child: CircularProgressIndicator(
                                 backgroundColor: Colors.transparent,

--- a/lib/src/widgets/core/pod_core_player.dart
+++ b/lib/src/widgets/core/pod_core_player.dart
@@ -4,6 +4,7 @@ class _PodCoreVideoPlayer extends StatelessWidget {
   final VideoPlayerController videoPlayerCtr;
   final double videoAspectRatio;
   final String tag;
+
   const _PodCoreVideoPlayer({
     Key? key,
     required this.videoPlayerCtr,
@@ -42,7 +43,9 @@ class _PodCoreVideoPlayer extends StatelessWidget {
                   tag: tag,
                   id: 'video-progress',
                   builder: (_podCtr) {
-                    if (_podCtr.videoThumbnail == null) return const SizedBox();
+                    if (_podCtr.videoThumbnail == null) {
+                      return const SizedBox();
+                    }
 
                     if (_podCtr.podVideoState == PodVideoState.paused &&
                         _podCtr.videoPosition == Duration.zero) {
@@ -72,13 +75,16 @@ class _PodCoreVideoPlayer extends StatelessWidget {
                   tag: tag,
                   id: 'podVideoState',
                   builder: (_podCtr) {
-                    const loadingWidget = Center(
-                      child: CircularProgressIndicator(
-                        backgroundColor: Colors.transparent,
-                        color: Colors.white,
-                        strokeWidth: 2,
-                      ),
-                    );
+                    final loadingWidget =
+                        _podCtr.podPlayerConfig.onLoading?.call() ??
+                            const Center(
+                              child: CircularProgressIndicator(
+                                backgroundColor: Colors.transparent,
+                                color: Colors.white,
+                                strokeWidth: 2,
+                              ),
+                            );
+
                     if (kIsWeb) {
                       switch (_podCtr.podVideoState) {
                         case PodVideoState.loading:

--- a/lib/src/widgets/full_screen_view.dart
+++ b/lib/src/widgets/full_screen_view.dart
@@ -32,7 +32,7 @@ class _FullScreenViewState extends State<FullScreenView>
 
   @override
   Widget build(BuildContext context) {
-    final loadingWidget = _podCtr.podPlayerConfig.onLoading?.call() ??
+    final loadingWidget = _podCtr.onLoading?.call(context) ??
         const CircularProgressIndicator(
           backgroundColor: Colors.black87,
           color: Colors.white,

--- a/lib/src/widgets/full_screen_view.dart
+++ b/lib/src/widgets/full_screen_view.dart
@@ -32,21 +32,23 @@ class _FullScreenViewState extends State<FullScreenView>
 
   @override
   Widget build(BuildContext context) {
-    const circularProgressIndicator = CircularProgressIndicator(
-      backgroundColor: Colors.black87,
-      color: Colors.white,
-      strokeWidth: 2,
-    );
+    final loadingWidget = _podCtr.podPlayerConfig.onLoading?.call() ??
+        const CircularProgressIndicator(
+          backgroundColor: Colors.black87,
+          color: Colors.white,
+          strokeWidth: 2,
+        );
+
     return WillPopScope(
       onWillPop: () async {
         if (kIsWeb) {
-          _podCtr.disableFullScreen(
+          await _podCtr.disableFullScreen(
             context,
             widget.tag,
             enablePop: false,
           );
         }
-        if (!kIsWeb) _podCtr.disableFullScreen(context, widget.tag);
+        if (!kIsWeb) await _podCtr.disableFullScreen(context, widget.tag);
         return true;
       },
       child: Scaffold(
@@ -61,7 +63,7 @@ class _FullScreenViewState extends State<FullScreenView>
                 width: MediaQuery.of(context).size.width,
                 child: Center(
                   child: _podCtr.videoCtr == null
-                      ? circularProgressIndicator
+                      ? loadingWidget
                       : _podCtr.videoCtr!.value.isInitialized
                           ? _PodCoreVideoPlayer(
                               tag: widget.tag,
@@ -69,7 +71,7 @@ class _FullScreenViewState extends State<FullScreenView>
                               videoAspectRatio:
                                   _podCtr.videoCtr?.value.aspectRatio ?? 16 / 9,
                             )
-                          : circularProgressIndicator,
+                          : loadingWidget,
                 ),
               ),
             ),


### PR DESCRIPTION
### If accepted, this PR will...

#### Add video quality priority list:  

The `videoQualityPriority` defines a preference of video quality. The first item available will be used. In the following example, if 1080p is available, it'll be used, otherwise, the next item will be analyzed. If 720p is available, then it'll be used. If just invalid options are set to videoQualityPriority, the first quality available will be used.
```dart 
controller = PodPlayerController(
  podPlayerConfig: const PodPlayerConfig(
    videoQualityPriority: [1080, 720, 360],
  ),
)..initialise()
```

#### Change onToggleFullScreen behavior:  

The onToggleFullScreen callback was changed to be asynchronous. If this callback is set, the user needs to handle manually the `SystemChrome.setPreferredOrientations` and `SystemChrome.setEnabledSystemUIMode` methods. This allow users to define their own list of preferred orientations...


#### Add onLoading Widget callback:  
An additional WidgetBuilder called onLoading was added to allow users to define their own progress indicator Widget.



(This PR includes the previous changes sent via PR #50, sorry for that...)