### PR TITLE
🚀  Fixed issue #115 previous PR there some conflict 🍬

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 </h1>
 
 <p align="center">
-  <a href="https://pub.dev/packages/pod_player/score"><img src="https://badges.bar/pod_player/likes" alt="pub likes"></a>
-  <a href="https://pub.dev/packages/pod_player"><img src="https://img.shields.io/pub/v/pod_player?style=flat" alt="pub version"></a>
-  <a href="https://pub.dev/packages/pod_player/score"><img src="https://badges.bar/pod_player/popularity" alt="popularity"></a>
-  <a href="https://pub.dev/packages/pod_player/score"><img src="https://badges.bar/pod_player/pub%20points" alt="pub points"></a>
+  <a href="https://pub.dev/packages/pod_player/score"><img src="https://img.shields.io/badge/Likes-200+-yellowgreen" alt="pub likes"></a>
+  <a href="https://pub.dev/packages/pod_player"><img src="https://img.shields.io/badge/pub version-0.1.6-blue" alt="pub version"></a>
+  <a href="https://pub.dev/packages/pod_player/score"><img src="https://img.shields.io/badge/popularity-140-critical" alt="popularity"></a>
+  <a href="https://pub.dev/packages/pod_player/score"><img src="https://img.shields.io/badge/popularity-97﹪-critical" alt="pub points"></a>
 
 </p>
 Video player for flutter web & mobile devices, pod player supports playing video from `Youtube` and `Vimeo`
@@ -17,11 +17,11 @@ This plugin built upon flutter's official [`video_player`](https://pub.dartlang.
 
 ---
 
-| PLATFORM | AVAILABLE |
-| :------: | :-------: |
-| Android  |    ✅     |
-|   IOS    |    ✅     |
-|   WEB    |    ✅     |
+| PLATFORM | AVAILABLE |       SUPPORTED PRODUCTION       |
+| :------: | :-------: | :------------------------------: |
+| Android  |    ✅     |                ✅                |
+|   IOS    |    ✅     |                ✅                |
+|   WEB    |    ✅     | ❌ Not recommended in production |
 
 ## Features
 
@@ -69,12 +69,12 @@ This plugin built upon flutter's official [`video_player`](https://pub.dartlang.
 </h1>
 
 - Video player on web
+
 ---
 
 <h1 align="center">
   <a><img src="https://user-images.githubusercontent.com/85326522/160885274-41be06af-ae6d-41f3-8cff-21767fde8dad.gif" alt="pod_player"></a>
 </h1>
-
 
 - Vimeo player and custom video player
 
@@ -121,7 +121,6 @@ This plugin built upon flutter's official [`video_player`](https://pub.dartlang.
 ![](https://user-images.githubusercontent.com/85326522/156824569-d1ec705d-c278-4503-81fb-84e9dcb58336.jpg)
 
 ---
-
 
 ## Usage
 
@@ -440,14 +439,14 @@ class PlayVideoFromVimeoPrivateVideo extends StatefulWidget {
           _PlayVideoFromVimeoPrivateVideoState();
 }
 
-class _PlayVideoFromVimeoPrivateVideoState 
+class _PlayVideoFromVimeoPrivateVideoState
     extends State<PlayVideoFromVimeoPrivateVideo> {
   late final PodPlayerController controller;
 
   @override
   void initState() {
-    String videoId = 'your private video id'; 
-    String token = 'your access token'; 
+    String videoId = 'your private video id';
+    String token = 'your access token';
     final Map<String, String> headers = <String, String>{};
     headers['Authorization'] = 'Bearer ${token}';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pod_player
 description: Vimeo and youtube player for flutter, Pod player provides customizable video player controls that support android, ios and web.
-version: 0.1.4
+version: 0.1.6
 homepage: https://github.com/newtaDev/pod_player
 
 environment:
@@ -17,6 +17,7 @@ dependencies:
   wakelock: ^0.6.2 
   universal_html: ^2.2.1 
   youtube_explode_dart: ^1.12.4
+  csslib: 0.17.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## What was the issue? #115 

I investigated the root cause of the error and found that it was related to the [universal_html](https://github.com/dint-dev/universal_html) package's lack of full support for null safety.

> Yesterday a new version was released for this lib and it broke universal_html. This will limit the `csslib` to be of old version instead of always updating whenever there is a new version 

To fix the error, I decided to Add `csslib` package with `0.17.0` in `pubspec.yaml`

### Tested
---

| _ | _ |       
| :------: | :-------: | 
| Android  |    ✅ PASS|   
|   IOS    |    ✅ PASS| 
|   WEB    |    ✅ PASS|

---
### Readme.md Updates Improvements

- [x] I made updates to the Readme.md file to provide clear information about the supported production and testing environments. also updated shield badges.