### PR TITLE
fix: migrate to wakelock_plus

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
-import wakelock_macos
+import package_info_plus
+import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  WakelockMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockMacosPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
+  WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/lib/src/controllers/pod_getx_video_controller.dart
+++ b/lib/src/controllers/pod_getx_video_controller.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:universal_html/html.dart' as _html;
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../pod_player.dart';
 import '../utils/logger.dart';
@@ -257,18 +257,18 @@ class PodGetXVideoController extends _PodGesturesController {
     podLog(_podVideoState.toString());
     switch (_podVideoState) {
       case PodVideoState.playing:
-        if (podPlayerConfig.wakelockEnabled) Wakelock.enable();
+        if (podPlayerConfig.wakelockEnabled) WakelockPlus.enable();
         playVideo(true);
         break;
       case PodVideoState.paused:
-        if (podPlayerConfig.wakelockEnabled) Wakelock.disable();
+        if (podPlayerConfig.wakelockEnabled) WakelockPlus.disable();
         playVideo(false);
         break;
       case PodVideoState.loading:
         isShowOverlay(true);
         break;
       case PodVideoState.error:
-        if (podPlayerConfig.wakelockEnabled) Wakelock.disable();
+        if (podPlayerConfig.wakelockEnabled) WakelockPlus.disable();
         playVideo(false);
         break;
     }

--- a/lib/src/controllers/pod_player_controller.dart
+++ b/lib/src/controllers/pod_player_controller.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:universal_html/html.dart' as _html;
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../pod_player.dart';
 import '../utils/logger.dart';
@@ -166,7 +166,7 @@ class PodPlayerController {
     _ctr.videoCtr?.removeListener(_ctr.videoListner);
     _ctr.videoCtr?.dispose();
     _ctr.removeListenerId('podVideoState', _ctr.podStateListner);
-    if (podPlayerConfig.wakelockEnabled) Wakelock.disable();
+    if (podPlayerConfig.wakelockEnabled) WakelockPlus.disable();
     Get.delete<PodGetXVideoController>(
       force: true,
       tag: getTag,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   video_player: ^2.6.1
   http: ^0.13.6  
   get: ^4.6.5  
-  wakelock: ^0.6.2 
+  wakelock_plus: ^1.0.0
   universal_html: ^2.2.3 
   youtube_explode_dart: ^1.12.4
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   video_player: ^2.6.1
   http: ^0.13.6  
   get: ^4.6.5  
-  wakelock_plus: ^1.0.0
+  wakelock_plus: ^1.0.0+3
   universal_html: ^2.2.3 
   youtube_explode_dart: ^1.12.4
 dev_dependencies:


### PR DESCRIPTION
Should resolve #124 

A simple migration to wakelock_plus - a continuation of original Wakelock library that is still maintained and published under [Flutter Community](https://github.com/fluttercommunity/community)