### PR TITLE
fix: UniqueKey does not work for controller tag when building app on release mode in Flutter 3.22

### DIFF
--- a/lib/src/controllers/pod_player_controller.dart
+++ b/lib/src/controllers/pod_player_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:universal_html/html.dart' as uni_html;
+import 'package:uuid/uuid.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../pod_player.dart';
@@ -29,7 +30,7 @@ class PodPlayerController {
   }
 
   void _init() {
-    getTag = UniqueKey().toString();
+    getTag = const Uuid().v4();
     Get.config(enableLog: PodVideoPlayer.enableGetxLogs);
     _ctr = Get.put(PodGetXVideoController(), permanent: true, tag: getTag)
       ..config(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   wakelock_plus: ^1.2.4
   universal_html: ^2.2.4
   youtube_explode_dart: ^2.2.0
+  uuid: ^4.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi, the `PodPlayerController` uses `UniqueKey().toString()` to generate a tag for the internal `PodGetXController`. However, in Flutter 3.22, there is an [issue](https://github.com/flutter/flutter/issues/149406) that `UniqueKey` always returns "Instance of UniqueKey" in release mode. No matter how many `PodPlayerController` are created, they still share the same `PodGetXController` instance.

To address this issue, I've replaced the usage of `UniqueKey` with `Uuid` for tag generation in the `PodPlayerController` class. `Uuid` is a safer and more standard approach for generating unique identifiers, and it ensures that each `PodPlayerController` instance will have a unique tag.

This change affects the `_init` method in the `PodPlayerController` class, where the `getTag` variable is assigned. I've tested the changes and confirmed that each `PodPlayerController` instance now receives a unique `PodGetXVideoController` instance as expected.